### PR TITLE
Make Rails a development dependency

### DIFF
--- a/edtf-humanize.gemspec
+++ b/edtf-humanize.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0"
   s.add_dependency "edtf", "~> 2.3"
+  s.add_dependency "activesupport", ">= 4", "< 6"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rails", ">= 4", "< 6"
 end


### PR DESCRIPTION
As far as I can tell no part of this library actually requires Rails or ActiveSupport, only the tests.