### PR TITLE
Allow EDTF version 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
-gem 'edtf', "~> 2.3"
+gem 'edtf', '>= 2.3', '< 4'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/edtf-humanize.gemspec
+++ b/edtf-humanize.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "edtf", "~> 2.3"
+  s.add_dependency "edtf", ">= 2.3", "< 4"
   s.add_dependency "activesupport", ">= 4", "< 6"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
The tests still pass with EDTF 3. I believe the main change in EDTF is just allowing AS5.