### PR TITLE
Allow ruby 4

### DIFF
--- a/edtf-humanize.gemspec
+++ b/edtf-humanize.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
                   'EDTF::Interval, EDTF::Set, EDTF::Season, EDTF::Unknown, ' \
                   'and Date (ISO 8601 compliant) objects.'
   s.license     = 'BSD-3-Clause'
-  s.required_ruby_version = '>= 2.4', '< 4'
+  s.required_ruby_version = '>= 2.4'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE.txt', 'README.rdoc']
 


### PR DESCRIPTION
Ruby 4 has been released and when testing it out my application downgraded to edtf-humanize 1.0.0 (from 2.3.0) as the latest version which allows ruby 4.  Is there a reason why 2.x versions don't allow ruby 4 or could the ruby version restrictions be relaxed so this doesn't keep happening with each ruby release?